### PR TITLE
[Feature] Adds `children` prop to all icons

### DIFF
--- a/src/icons/activity.js
+++ b/src/icons/activity.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Activity = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const Activity = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
     </svg>
   );
 };
 
 Activity.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Activity.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/airplay.js
+++ b/src/icons/airplay.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Airplay = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Airplay = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M5 17H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2h-1" />
       <polygon points="12 15 17 21 7 21 12 15" />
     </svg>
@@ -23,11 +24,13 @@ const Airplay = props => {
 };
 
 Airplay.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Airplay.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/alert-circle.js
+++ b/src/icons/alert-circle.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const AlertCircle = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const AlertCircle = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <circle cx="12" cy="12" r="10" />
       <line x1="12" y1="8" x2="12" y2="12" />
       <line x1="12" y1="16" x2="12" y2="16" />
@@ -24,11 +25,13 @@ const AlertCircle = props => {
 };
 
 AlertCircle.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 AlertCircle.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/alert-octagon.js
+++ b/src/icons/alert-octagon.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const AlertOctagon = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const AlertOctagon = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polygon points="7.86 2 16.14 2 22 7.86 22 16.14 16.14 22 7.86 22 2 16.14 2 7.86 7.86 2" />
       <line x1="12" y1="8" x2="12" y2="12" />
       <line x1="12" y1="16" x2="12" y2="16" />
@@ -24,11 +25,13 @@ const AlertOctagon = props => {
 };
 
 AlertOctagon.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 AlertOctagon.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/alert-triangle.js
+++ b/src/icons/alert-triangle.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const AlertTriangle = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const AlertTriangle = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
       <line x1="12" y1="9" x2="12" y2="13" />
       <line x1="12" y1="17" x2="12" y2="17" />
@@ -24,11 +25,13 @@ const AlertTriangle = props => {
 };
 
 AlertTriangle.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 AlertTriangle.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/align-center.js
+++ b/src/icons/align-center.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const AlignCenter = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const AlignCenter = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <line x1="18" y1="10" x2="6" y2="10" />
       <line x1="21" y1="6" x2="3" y2="6" />
       <line x1="21" y1="14" x2="3" y2="14" />
@@ -25,11 +26,13 @@ const AlignCenter = props => {
 };
 
 AlignCenter.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 AlignCenter.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/align-justify.js
+++ b/src/icons/align-justify.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const AlignJustify = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const AlignJustify = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <line x1="21" y1="10" x2="3" y2="10" />
       <line x1="21" y1="6" x2="3" y2="6" />
       <line x1="21" y1="14" x2="3" y2="14" />
@@ -25,11 +26,13 @@ const AlignJustify = props => {
 };
 
 AlignJustify.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 AlignJustify.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/align-left.js
+++ b/src/icons/align-left.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const AlignLeft = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const AlignLeft = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <line x1="17" y1="10" x2="3" y2="10" />
       <line x1="21" y1="6" x2="3" y2="6" />
       <line x1="21" y1="14" x2="3" y2="14" />
@@ -25,11 +26,13 @@ const AlignLeft = props => {
 };
 
 AlignLeft.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 AlignLeft.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/align-right.js
+++ b/src/icons/align-right.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const AlignRight = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const AlignRight = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <line x1="21" y1="10" x2="7" y2="10" />
       <line x1="21" y1="6" x2="3" y2="6" />
       <line x1="21" y1="14" x2="3" y2="14" />
@@ -25,11 +26,13 @@ const AlignRight = props => {
 };
 
 AlignRight.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 AlignRight.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/anchor.js
+++ b/src/icons/anchor.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Anchor = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Anchor = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <circle cx="12" cy="5" r="3" />
       <line x1="12" y1="22" x2="12" y2="8" />
       <path d="M5 12H2a10 10 0 0 0 20 0h-3" />
@@ -24,11 +25,13 @@ const Anchor = props => {
 };
 
 Anchor.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Anchor.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/aperture.js
+++ b/src/icons/aperture.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Aperture = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Aperture = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <circle cx="12" cy="12" r="10" />
       <line x1="14.31" y1="8" x2="20.05" y2="17.94" />
       <line x1="9.69" y1="8" x2="21.17" y2="8" />
@@ -28,11 +29,13 @@ const Aperture = props => {
 };
 
 Aperture.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Aperture.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/arrow-down-circle.js
+++ b/src/icons/arrow-down-circle.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const ArrowDownCircle = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const ArrowDownCircle = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <circle cx="12" cy="12" r="10" />
       <polyline points="8 12 12 16 16 12" />
       <line x1="12" y1="8" x2="12" y2="16" />
@@ -24,11 +25,13 @@ const ArrowDownCircle = props => {
 };
 
 ArrowDownCircle.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 ArrowDownCircle.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/arrow-down-left.js
+++ b/src/icons/arrow-down-left.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const ArrowDownLeft = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const ArrowDownLeft = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <line x1="17" y1="7" x2="7" y2="17" />
       <polyline points="17 17 7 17 7 7" />
     </svg>
@@ -23,11 +24,13 @@ const ArrowDownLeft = props => {
 };
 
 ArrowDownLeft.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 ArrowDownLeft.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/arrow-down-right.js
+++ b/src/icons/arrow-down-right.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const ArrowDownRight = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const ArrowDownRight = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <line x1="7" y1="7" x2="17" y2="17" />
       <polyline points="17 7 17 17 7 17" />
     </svg>
@@ -23,11 +24,13 @@ const ArrowDownRight = props => {
 };
 
 ArrowDownRight.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 ArrowDownRight.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/arrow-down.js
+++ b/src/icons/arrow-down.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const ArrowDown = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const ArrowDown = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <line x1="12" y1="5" x2="12" y2="19" />
       <polyline points="19 12 12 19 5 12" />
     </svg>
@@ -23,11 +24,13 @@ const ArrowDown = props => {
 };
 
 ArrowDown.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 ArrowDown.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/arrow-left-circle.js
+++ b/src/icons/arrow-left-circle.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const ArrowLeftCircle = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const ArrowLeftCircle = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <circle cx="12" cy="12" r="10" />
       <polyline points="12 8 8 12 12 16" />
       <line x1="16" y1="12" x2="8" y2="12" />
@@ -24,11 +25,13 @@ const ArrowLeftCircle = props => {
 };
 
 ArrowLeftCircle.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 ArrowLeftCircle.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/arrow-left.js
+++ b/src/icons/arrow-left.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const ArrowLeft = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const ArrowLeft = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <line x1="19" y1="12" x2="5" y2="12" />
       <polyline points="12 19 5 12 12 5" />
     </svg>
@@ -23,11 +24,13 @@ const ArrowLeft = props => {
 };
 
 ArrowLeft.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 ArrowLeft.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/arrow-right-circle.js
+++ b/src/icons/arrow-right-circle.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const ArrowRightCircle = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const ArrowRightCircle = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <circle cx="12" cy="12" r="10" />
       <polyline points="12 16 16 12 12 8" />
       <line x1="8" y1="12" x2="16" y2="12" />
@@ -24,11 +25,13 @@ const ArrowRightCircle = props => {
 };
 
 ArrowRightCircle.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 ArrowRightCircle.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/arrow-right.js
+++ b/src/icons/arrow-right.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const ArrowRight = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const ArrowRight = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <line x1="5" y1="12" x2="19" y2="12" />
       <polyline points="12 5 19 12 12 19" />
     </svg>
@@ -23,11 +24,13 @@ const ArrowRight = props => {
 };
 
 ArrowRight.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 ArrowRight.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/arrow-up-circle.js
+++ b/src/icons/arrow-up-circle.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const ArrowUpCircle = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const ArrowUpCircle = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <circle cx="12" cy="12" r="10" />
       <polyline points="16 12 12 8 8 12" />
       <line x1="12" y1="16" x2="12" y2="8" />
@@ -24,11 +25,13 @@ const ArrowUpCircle = props => {
 };
 
 ArrowUpCircle.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 ArrowUpCircle.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/arrow-up-left.js
+++ b/src/icons/arrow-up-left.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const ArrowUpLeft = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const ArrowUpLeft = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <line x1="17" y1="17" x2="7" y2="7" />
       <polyline points="7 17 7 7 17 7" />
     </svg>
@@ -23,11 +24,13 @@ const ArrowUpLeft = props => {
 };
 
 ArrowUpLeft.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 ArrowUpLeft.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/arrow-up-right.js
+++ b/src/icons/arrow-up-right.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const ArrowUpRight = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const ArrowUpRight = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <line x1="7" y1="17" x2="17" y2="7" />
       <polyline points="7 7 17 7 17 17" />
     </svg>
@@ -23,11 +24,13 @@ const ArrowUpRight = props => {
 };
 
 ArrowUpRight.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 ArrowUpRight.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/arrow-up.js
+++ b/src/icons/arrow-up.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const ArrowUp = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const ArrowUp = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <line x1="12" y1="19" x2="12" y2="5" />
       <polyline points="5 12 12 5 19 12" />
     </svg>
@@ -23,11 +24,13 @@ const ArrowUp = props => {
 };
 
 ArrowUp.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 ArrowUp.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/at-sign.js
+++ b/src/icons/at-sign.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const AtSign = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const AtSign = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <circle cx="12" cy="12" r="4" />
       <path d="M16 8v5a3 3 0 0 0 6 0v-1a10 10 0 1 0-3.92 7.94" />
     </svg>
@@ -23,11 +24,13 @@ const AtSign = props => {
 };
 
 AtSign.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 AtSign.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/award.js
+++ b/src/icons/award.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Award = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Award = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <circle cx="12" cy="8" r="7" />
       <polyline points="8.21 13.89 7 23 12 20 17 23 15.79 13.88" />
     </svg>
@@ -23,11 +24,13 @@ const Award = props => {
 };
 
 Award.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Award.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/bar-chart-2.js
+++ b/src/icons/bar-chart-2.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const BarChart2 = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const BarChart2 = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <line x1="18" y1="20" x2="18" y2="10" />
       <line x1="12" y1="20" x2="12" y2="4" />
       <line x1="6" y1="20" x2="6" y2="14" />
@@ -24,11 +25,13 @@ const BarChart2 = props => {
 };
 
 BarChart2.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 BarChart2.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/bar-chart.js
+++ b/src/icons/bar-chart.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const BarChart = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const BarChart = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <line x1="12" y1="20" x2="12" y2="10" />
       <line x1="18" y1="20" x2="18" y2="4" />
       <line x1="6" y1="20" x2="6" y2="16" />
@@ -24,11 +25,13 @@ const BarChart = props => {
 };
 
 BarChart.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 BarChart.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/battery-charging.js
+++ b/src/icons/battery-charging.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const BatteryCharging = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const BatteryCharging = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M5 18H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h3.19M15 6h2a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2h-3.19" />
       <line x1="23" y1="13" x2="23" y2="11" />
       <polyline points="11 6 7 12 13 12 9 18" />
@@ -24,11 +25,13 @@ const BatteryCharging = props => {
 };
 
 BatteryCharging.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 BatteryCharging.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/battery.js
+++ b/src/icons/battery.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Battery = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Battery = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <rect x="1" y="6" width="18" height="12" rx="2" ry="2" />
       <line x1="23" y1="13" x2="23" y2="11" />
     </svg>
@@ -23,11 +24,13 @@ const Battery = props => {
 };
 
 Battery.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Battery.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/bell-off.js
+++ b/src/icons/bell-off.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const BellOff = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const BellOff = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M8.56 2.9A7 7 0 0 1 19 9v4m-2 4H2a3 3 0 0 0 3-3V9a7 7 0 0 1 .78-3.22M13.73 21a2 2 0 0 1-3.46 0" />
       <line x1="1" y1="1" x2="23" y2="23" />
     </svg>
@@ -23,11 +24,13 @@ const BellOff = props => {
 };
 
 BellOff.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 BellOff.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/bell.js
+++ b/src/icons/bell.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Bell = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const Bell = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M22 17H2a3 3 0 0 0 3-3V9a7 7 0 0 1 14 0v5a3 3 0 0 0 3 3zm-8.27 4a2 2 0 0 1-3.46 0" />
     </svg>
   );
 };
 
 Bell.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Bell.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/bluetooth.js
+++ b/src/icons/bluetooth.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Bluetooth = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const Bluetooth = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="6.5 6.5 17.5 17.5 12 23 12 1 17.5 6.5 6.5 17.5" />
     </svg>
   );
 };
 
 Bluetooth.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Bluetooth.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/bold.js
+++ b/src/icons/bold.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Bold = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Bold = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M6 4h8a4 4 0 0 1 4 4 4 4 0 0 1-4 4H6z" />
       <path d="M6 12h9a4 4 0 0 1 4 4 4 4 0 0 1-4 4H6z" />
     </svg>
@@ -23,11 +24,13 @@ const Bold = props => {
 };
 
 Bold.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Bold.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/book-open.js
+++ b/src/icons/book-open.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const BookOpen = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const BookOpen = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z" />
       <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z" />
     </svg>
@@ -23,11 +24,13 @@ const BookOpen = props => {
 };
 
 BookOpen.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 BookOpen.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/book.js
+++ b/src/icons/book.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Book = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Book = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
       <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
     </svg>
@@ -23,11 +24,13 @@ const Book = props => {
 };
 
 Book.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Book.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/bookmark.js
+++ b/src/icons/bookmark.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Bookmark = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const Bookmark = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
     </svg>
   );
 };
 
 Bookmark.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Bookmark.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/box.js
+++ b/src/icons/box.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Box = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Box = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M12.89 1.45l8 4A2 2 0 0 1 22 7.24v9.53a2 2 0 0 1-1.11 1.79l-8 4a2 2 0 0 1-1.79 0l-8-4a2 2 0 0 1-1.1-1.8V7.24a2 2 0 0 1 1.11-1.79l8-4a2 2 0 0 1 1.78 0z" />
       <polyline points="2.32 6.16 12 11 21.68 6.16" />
       <line x1="12" y1="22.76" x2="12" y2="11" />
@@ -24,11 +25,13 @@ const Box = props => {
 };
 
 Box.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Box.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/briefcase.js
+++ b/src/icons/briefcase.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Briefcase = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Briefcase = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <rect x="2" y="7" width="20" height="14" rx="2" ry="2" />
       <path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16" />
     </svg>
@@ -23,11 +24,13 @@ const Briefcase = props => {
 };
 
 Briefcase.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Briefcase.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/calendar.js
+++ b/src/icons/calendar.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Calendar = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Calendar = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
       <line x1="16" y1="2" x2="16" y2="6" />
       <line x1="8" y1="2" x2="8" y2="6" />
@@ -25,11 +26,13 @@ const Calendar = props => {
 };
 
 Calendar.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Calendar.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/camera-off.js
+++ b/src/icons/camera-off.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const CameraOff = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const CameraOff = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <line x1="1" y1="1" x2="23" y2="23" />
       <path d="M21 21H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h3m3-3h6l2 3h4a2 2 0 0 1 2 2v9.34m-7.72-2.06a4 4 0 1 1-5.56-5.56" />
     </svg>
@@ -23,11 +24,13 @@ const CameraOff = props => {
 };
 
 CameraOff.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 CameraOff.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/camera.js
+++ b/src/icons/camera.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Camera = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Camera = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z" />
       <circle cx="12" cy="13" r="4" />
     </svg>
@@ -23,11 +24,13 @@ const Camera = props => {
 };
 
 Camera.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Camera.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/cast.js
+++ b/src/icons/cast.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Cast = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Cast = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M2 16.1A5 5 0 0 1 5.9 20M2 12.05A9 9 0 0 1 9.95 20M2 8V6a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2h-6" />
       <line x1="2" y1="20" x2="2" y2="20" />
     </svg>
@@ -23,11 +24,13 @@ const Cast = props => {
 };
 
 Cast.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Cast.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/check-circle.js
+++ b/src/icons/check-circle.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const CheckCircle = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const CheckCircle = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
       <polyline points="22 4 12 14.01 9 11.01" />
     </svg>
@@ -23,11 +24,13 @@ const CheckCircle = props => {
 };
 
 CheckCircle.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 CheckCircle.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/check-square.js
+++ b/src/icons/check-square.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const CheckSquare = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const CheckSquare = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="9 11 12 14 22 4" />
       <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11" />
     </svg>
@@ -23,11 +24,13 @@ const CheckSquare = props => {
 };
 
 CheckSquare.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 CheckSquare.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/check.js
+++ b/src/icons/check.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Check = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const Check = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="20 6 9 17 4 12" />
     </svg>
   );
 };
 
 Check.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Check.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/chevron-down.js
+++ b/src/icons/chevron-down.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const ChevronDown = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const ChevronDown = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="6 9 12 15 18 9" />
     </svg>
   );
 };
 
 ChevronDown.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 ChevronDown.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/chevron-left.js
+++ b/src/icons/chevron-left.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const ChevronLeft = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const ChevronLeft = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="15 18 9 12 15 6" />
     </svg>
   );
 };
 
 ChevronLeft.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 ChevronLeft.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/chevron-right.js
+++ b/src/icons/chevron-right.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const ChevronRight = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const ChevronRight = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="9 18 15 12 9 6" />
     </svg>
   );
 };
 
 ChevronRight.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 ChevronRight.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/chevron-up.js
+++ b/src/icons/chevron-up.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const ChevronUp = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const ChevronUp = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="18 15 12 9 6 15" />
     </svg>
   );
 };
 
 ChevronUp.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 ChevronUp.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/chevrons-down.js
+++ b/src/icons/chevrons-down.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const ChevronsDown = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const ChevronsDown = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="7 13 12 18 17 13" />
       <polyline points="7 6 12 11 17 6" />
     </svg>
@@ -23,11 +24,13 @@ const ChevronsDown = props => {
 };
 
 ChevronsDown.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 ChevronsDown.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/chevrons-left.js
+++ b/src/icons/chevrons-left.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const ChevronsLeft = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const ChevronsLeft = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="11 17 6 12 11 7" />
       <polyline points="18 17 13 12 18 7" />
     </svg>
@@ -23,11 +24,13 @@ const ChevronsLeft = props => {
 };
 
 ChevronsLeft.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 ChevronsLeft.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/chevrons-right.js
+++ b/src/icons/chevrons-right.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const ChevronsRight = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const ChevronsRight = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="13 17 18 12 13 7" />
       <polyline points="6 17 11 12 6 7" />
     </svg>
@@ -23,11 +24,13 @@ const ChevronsRight = props => {
 };
 
 ChevronsRight.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 ChevronsRight.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/chevrons-up.js
+++ b/src/icons/chevrons-up.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const ChevronsUp = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const ChevronsUp = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="17 11 12 6 7 11" />
       <polyline points="17 18 12 13 7 18" />
     </svg>
@@ -23,11 +24,13 @@ const ChevronsUp = props => {
 };
 
 ChevronsUp.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 ChevronsUp.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/chrome.js
+++ b/src/icons/chrome.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Chrome = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Chrome = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <circle cx="12" cy="12" r="10" />
       <circle cx="12" cy="12" r="4" />
       <line x1="21.17" y1="8" x2="12" y2="8" />
@@ -26,11 +27,13 @@ const Chrome = props => {
 };
 
 Chrome.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Chrome.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/circle.js
+++ b/src/icons/circle.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Circle = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const Circle = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <circle cx="12" cy="12" r="10" />
     </svg>
   );
 };
 
 Circle.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Circle.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/clipboard.js
+++ b/src/icons/clipboard.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Clipboard = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Clipboard = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" />
       <rect x="8" y="2" width="8" height="4" rx="1" ry="1" />
     </svg>
@@ -23,11 +24,13 @@ const Clipboard = props => {
 };
 
 Clipboard.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Clipboard.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/clock.js
+++ b/src/icons/clock.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Clock = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Clock = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <circle cx="12" cy="12" r="10" />
       <polyline points="12 6 12 12 16 14" />
     </svg>
@@ -23,11 +24,13 @@ const Clock = props => {
 };
 
 Clock.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Clock.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/cloud-drizzle.js
+++ b/src/icons/cloud-drizzle.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const CloudDrizzle = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const CloudDrizzle = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <line x1="8" y1="19" x2="8" y2="21" />
       <line x1="8" y1="13" x2="8" y2="15" />
       <line x1="16" y1="19" x2="16" y2="21" />
@@ -28,11 +29,13 @@ const CloudDrizzle = props => {
 };
 
 CloudDrizzle.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 CloudDrizzle.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/cloud-lightning.js
+++ b/src/icons/cloud-lightning.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const CloudLightning = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const CloudLightning = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M19 16.9A5 5 0 0 0 18 7h-1.26a8 8 0 1 0-11.62 9" />
       <polyline points="13 11 9 17 15 17 11 23" />
     </svg>
@@ -23,11 +24,13 @@ const CloudLightning = props => {
 };
 
 CloudLightning.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 CloudLightning.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/cloud-off.js
+++ b/src/icons/cloud-off.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const CloudOff = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const CloudOff = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M22.61 16.95A5 5 0 0 0 18 10h-1.26a8 8 0 0 0-7.05-6M5 5a8 8 0 0 0 4 15h9a5 5 0 0 0 1.7-.3" />
       <line x1="1" y1="1" x2="23" y2="23" />
     </svg>
@@ -23,11 +24,13 @@ const CloudOff = props => {
 };
 
 CloudOff.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 CloudOff.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/cloud-rain.js
+++ b/src/icons/cloud-rain.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const CloudRain = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const CloudRain = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <line x1="16" y1="13" x2="16" y2="21" />
       <line x1="8" y1="13" x2="8" y2="21" />
       <line x1="12" y1="15" x2="12" y2="23" />
@@ -25,11 +26,13 @@ const CloudRain = props => {
 };
 
 CloudRain.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 CloudRain.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/cloud-snow.js
+++ b/src/icons/cloud-snow.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const CloudSnow = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const CloudSnow = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M20 17.58A5 5 0 0 0 18 8h-1.26A8 8 0 1 0 4 16.25" />
       <line x1="8" y1="16" x2="8" y2="16" />
       <line x1="8" y1="20" x2="8" y2="20" />
@@ -28,11 +29,13 @@ const CloudSnow = props => {
 };
 
 CloudSnow.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 CloudSnow.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/cloud.js
+++ b/src/icons/cloud.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Cloud = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const Cloud = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z" />
     </svg>
   );
 };
 
 Cloud.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Cloud.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/code.js
+++ b/src/icons/code.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Code = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Code = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="16 18 22 12 16 6" />
       <polyline points="8 6 2 12 8 18" />
     </svg>
@@ -23,11 +24,13 @@ const Code = props => {
 };
 
 Code.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Code.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/codepen.js
+++ b/src/icons/codepen.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Codepen = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Codepen = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polygon points="12 2 22 8.5 22 15.5 12 22 2 15.5 2 8.5 12 2" />
       <line x1="12" y1="22" x2="12" y2="15.5" />
       <polyline points="22 8.5 12 15.5 2 8.5" />
@@ -26,11 +27,13 @@ const Codepen = props => {
 };
 
 Codepen.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Codepen.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/command.js
+++ b/src/icons/command.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Command = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const Command = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M18 3a3 3 0 0 0-3 3v12a3 3 0 0 0 3 3 3 3 0 0 0 3-3 3 3 0 0 0-3-3H6a3 3 0 0 0-3 3 3 3 0 0 0 3 3 3 3 0 0 0 3-3V6a3 3 0 0 0-3-3 3 3 0 0 0-3 3 3 3 0 0 0 3 3h12a3 3 0 0 0 3-3 3 3 0 0 0-3-3z" />
     </svg>
   );
 };
 
 Command.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Command.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/compass.js
+++ b/src/icons/compass.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Compass = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Compass = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <circle cx="12" cy="12" r="10" />
       <polygon points="16.24 7.76 14.12 14.12 7.76 16.24 9.88 9.88 16.24 7.76" />
     </svg>
@@ -23,11 +24,13 @@ const Compass = props => {
 };
 
 Compass.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Compass.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/copy.js
+++ b/src/icons/copy.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Copy = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Copy = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
       <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
     </svg>
@@ -23,11 +24,13 @@ const Copy = props => {
 };
 
 Copy.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Copy.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/corner-down-left.js
+++ b/src/icons/corner-down-left.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const CornerDownLeft = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const CornerDownLeft = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="9 10 4 15 9 20" />
       <path d="M20 4v7a4 4 0 0 1-4 4H4" />
     </svg>
@@ -23,11 +24,13 @@ const CornerDownLeft = props => {
 };
 
 CornerDownLeft.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 CornerDownLeft.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/corner-down-right.js
+++ b/src/icons/corner-down-right.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const CornerDownRight = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const CornerDownRight = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="15 10 20 15 15 20" />
       <path d="M4 4v7a4 4 0 0 0 4 4h12" />
     </svg>
@@ -23,11 +24,13 @@ const CornerDownRight = props => {
 };
 
 CornerDownRight.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 CornerDownRight.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/corner-left-down.js
+++ b/src/icons/corner-left-down.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const CornerLeftDown = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const CornerLeftDown = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="14 15 9 20 4 15" />
       <path d="M20 4h-7a4 4 0 0 0-4 4v12" />
     </svg>
@@ -23,11 +24,13 @@ const CornerLeftDown = props => {
 };
 
 CornerLeftDown.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 CornerLeftDown.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/corner-left-up.js
+++ b/src/icons/corner-left-up.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const CornerLeftUp = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const CornerLeftUp = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="14 9 9 4 4 9" />
       <path d="M20 20h-7a4 4 0 0 1-4-4V4" />
     </svg>
@@ -23,11 +24,13 @@ const CornerLeftUp = props => {
 };
 
 CornerLeftUp.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 CornerLeftUp.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/corner-right-down.js
+++ b/src/icons/corner-right-down.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const CornerRightDown = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const CornerRightDown = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="10 15 15 20 20 15" />
       <path d="M4 4h7a4 4 0 0 1 4 4v12" />
     </svg>
@@ -23,11 +24,13 @@ const CornerRightDown = props => {
 };
 
 CornerRightDown.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 CornerRightDown.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/corner-right-up.js
+++ b/src/icons/corner-right-up.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const CornerRightUp = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const CornerRightUp = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="10 9 15 4 20 9" />
       <path d="M4 20h7a4 4 0 0 0 4-4V4" />
     </svg>
@@ -23,11 +24,13 @@ const CornerRightUp = props => {
 };
 
 CornerRightUp.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 CornerRightUp.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/corner-up-left.js
+++ b/src/icons/corner-up-left.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const CornerUpLeft = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const CornerUpLeft = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="9 14 4 9 9 4" />
       <path d="M20 20v-7a4 4 0 0 0-4-4H4" />
     </svg>
@@ -23,11 +24,13 @@ const CornerUpLeft = props => {
 };
 
 CornerUpLeft.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 CornerUpLeft.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/corner-up-right.js
+++ b/src/icons/corner-up-right.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const CornerUpRight = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const CornerUpRight = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="15 14 20 9 15 4" />
       <path d="M4 20v-7a4 4 0 0 1 4-4h12" />
     </svg>
@@ -23,11 +24,13 @@ const CornerUpRight = props => {
 };
 
 CornerUpRight.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 CornerUpRight.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/cpu.js
+++ b/src/icons/cpu.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Cpu = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Cpu = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <rect x="4" y="4" width="16" height="16" rx="2" ry="2" />
       <rect x="9" y="9" width="6" height="6" />
       <line x1="9" y1="1" x2="9" y2="4" />
@@ -31,11 +32,13 @@ const Cpu = props => {
 };
 
 Cpu.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Cpu.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/credit-card.js
+++ b/src/icons/credit-card.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const CreditCard = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const CreditCard = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <rect x="1" y="4" width="22" height="16" rx="2" ry="2" />
       <line x1="1" y1="10" x2="23" y2="10" />
     </svg>
@@ -23,11 +24,13 @@ const CreditCard = props => {
 };
 
 CreditCard.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 CreditCard.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/crop.js
+++ b/src/icons/crop.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Crop = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Crop = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M6.13 1L6 16a2 2 0 0 0 2 2h15" />
       <path d="M1 6.13L16 6a2 2 0 0 1 2 2v15" />
     </svg>
@@ -23,11 +24,13 @@ const Crop = props => {
 };
 
 Crop.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Crop.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/crosshair.js
+++ b/src/icons/crosshair.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Crosshair = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Crosshair = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <circle cx="12" cy="12" r="10" />
       <line x1="22" y1="12" x2="18" y2="12" />
       <line x1="6" y1="12" x2="2" y2="12" />
@@ -26,11 +27,13 @@ const Crosshair = props => {
 };
 
 Crosshair.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Crosshair.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/database.js
+++ b/src/icons/database.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Database = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Database = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <ellipse cx="12" cy="5" rx="9" ry="3" />
       <path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3" />
       <path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5" />
@@ -24,11 +25,13 @@ const Database = props => {
 };
 
 Database.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Database.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/delete.js
+++ b/src/icons/delete.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Delete = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Delete = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M21 4H8l-7 8 7 8h13a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2z" />
       <line x1="18" y1="9" x2="12" y2="15" />
       <line x1="12" y1="9" x2="18" y2="15" />
@@ -24,11 +25,13 @@ const Delete = props => {
 };
 
 Delete.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Delete.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/disc.js
+++ b/src/icons/disc.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Disc = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Disc = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <circle cx="12" cy="12" r="10" />
       <circle cx="12" cy="12" r="3" />
     </svg>
@@ -23,11 +24,13 @@ const Disc = props => {
 };
 
 Disc.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Disc.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/dollar-sign.js
+++ b/src/icons/dollar-sign.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const DollarSign = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const DollarSign = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <line x1="12" y1="1" x2="12" y2="23" />
       <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" />
     </svg>
@@ -23,11 +24,13 @@ const DollarSign = props => {
 };
 
 DollarSign.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 DollarSign.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/download-cloud.js
+++ b/src/icons/download-cloud.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const DownloadCloud = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const DownloadCloud = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="8 17 12 21 16 17" />
       <line x1="12" y1="12" x2="12" y2="21" />
       <path d="M20.88 18.09A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.29" />
@@ -24,11 +25,13 @@ const DownloadCloud = props => {
 };
 
 DownloadCloud.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 DownloadCloud.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/download.js
+++ b/src/icons/download.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Download = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Download = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
       <polyline points="7 10 12 15 17 10" />
       <line x1="12" y1="15" x2="12" y2="3" />
@@ -24,11 +25,13 @@ const Download = props => {
 };
 
 Download.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Download.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/droplet.js
+++ b/src/icons/droplet.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Droplet = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const Droplet = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M12 2.69l5.66 5.66a8 8 0 1 1-11.31 0z" />
     </svg>
   );
 };
 
 Droplet.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Droplet.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/edit-2.js
+++ b/src/icons/edit-2.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Edit2 = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const Edit2 = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polygon points="16 3 21 8 8 21 3 21 3 16 16 3" />
     </svg>
   );
 };
 
 Edit2.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Edit2.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/edit-3.js
+++ b/src/icons/edit-3.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Edit3 = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Edit3 = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polygon points="14 2 18 6 7 17 3 17 3 13 14 2" />
       <line x1="3" y1="22" x2="21" y2="22" />
     </svg>
@@ -23,11 +24,13 @@ const Edit3 = props => {
 };
 
 Edit3.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Edit3.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/edit.js
+++ b/src/icons/edit.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Edit = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Edit = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M20 14.66V20a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h5.34" />
       <polygon points="18 2 22 6 12 16 8 16 8 12 18 2" />
     </svg>
@@ -23,11 +24,13 @@ const Edit = props => {
 };
 
 Edit.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Edit.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/external-link.js
+++ b/src/icons/external-link.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const ExternalLink = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const ExternalLink = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
       <polyline points="15 3 21 3 21 9" />
       <line x1="10" y1="14" x2="21" y2="3" />
@@ -24,11 +25,13 @@ const ExternalLink = props => {
 };
 
 ExternalLink.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 ExternalLink.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/eye-off.js
+++ b/src/icons/eye-off.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const EyeOff = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const EyeOff = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24" />
       <line x1="1" y1="1" x2="23" y2="23" />
     </svg>
@@ -23,11 +24,13 @@ const EyeOff = props => {
 };
 
 EyeOff.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 EyeOff.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/eye.js
+++ b/src/icons/eye.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Eye = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Eye = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
       <circle cx="12" cy="12" r="3" />
     </svg>
@@ -23,11 +24,13 @@ const Eye = props => {
 };
 
 Eye.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Eye.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/facebook.js
+++ b/src/icons/facebook.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Facebook = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const Facebook = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M18 2h-3a5 5 0 0 0-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 0 1 1-1h3z" />
     </svg>
   );
 };
 
 Facebook.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Facebook.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/fast-forward.js
+++ b/src/icons/fast-forward.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const FastForward = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const FastForward = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polygon points="13 19 22 12 13 5 13 19" />
       <polygon points="2 19 11 12 2 5 2 19" />
     </svg>
@@ -23,11 +24,13 @@ const FastForward = props => {
 };
 
 FastForward.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 FastForward.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/feather.js
+++ b/src/icons/feather.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Feather = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Feather = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M20.24 12.24a6 6 0 0 0-8.49-8.49L5 10.5V19h8.5z" />
       <line x1="16" y1="8" x2="2" y2="22" />
       <line x1="17" y1="15" x2="9" y2="15" />
@@ -24,11 +25,13 @@ const Feather = props => {
 };
 
 Feather.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Feather.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/file-minus.js
+++ b/src/icons/file-minus.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const FileMinus = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const FileMinus = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
       <polyline points="14 2 14 8 20 8" />
       <line x1="9" y1="15" x2="15" y2="15" />
@@ -24,11 +25,13 @@ const FileMinus = props => {
 };
 
 FileMinus.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 FileMinus.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/file-plus.js
+++ b/src/icons/file-plus.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const FilePlus = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const FilePlus = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
       <polyline points="14 2 14 8 20 8" />
       <line x1="12" y1="18" x2="12" y2="12" />
@@ -25,11 +26,13 @@ const FilePlus = props => {
 };
 
 FilePlus.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 FilePlus.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/file-text.js
+++ b/src/icons/file-text.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const FileText = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const FileText = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
       <polyline points="14 2 14 8 20 8" />
       <line x1="16" y1="13" x2="8" y2="13" />
@@ -26,11 +27,13 @@ const FileText = props => {
 };
 
 FileText.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 FileText.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/file.js
+++ b/src/icons/file.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const File = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const File = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z" />
       <polyline points="13 2 13 9 20 9" />
     </svg>
@@ -23,11 +24,13 @@ const File = props => {
 };
 
 File.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 File.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/film.js
+++ b/src/icons/film.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Film = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Film = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <rect x="2" y="2" width="20" height="20" rx="2.18" ry="2.18" />
       <line x1="7" y1="2" x2="7" y2="22" />
       <line x1="17" y1="2" x2="17" y2="22" />
@@ -29,11 +30,13 @@ const Film = props => {
 };
 
 Film.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Film.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/filter.js
+++ b/src/icons/filter.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Filter = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const Filter = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3" />
     </svg>
   );
 };
 
 Filter.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Filter.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/flag.js
+++ b/src/icons/flag.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Flag = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Flag = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V3s-1 1-4 1-5-2-8-2-4 1-4 1z" />
       <line x1="4" y1="22" x2="4" y2="15" />
     </svg>
@@ -23,11 +24,13 @@ const Flag = props => {
 };
 
 Flag.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Flag.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/folder-minus.js
+++ b/src/icons/folder-minus.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const FolderMinus = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const FolderMinus = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
       <line x1="9" y1="14" x2="15" y2="14" />
     </svg>
@@ -23,11 +24,13 @@ const FolderMinus = props => {
 };
 
 FolderMinus.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 FolderMinus.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/folder-plus.js
+++ b/src/icons/folder-plus.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const FolderPlus = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const FolderPlus = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
       <line x1="12" y1="11" x2="12" y2="17" />
       <line x1="9" y1="14" x2="15" y2="14" />
@@ -24,11 +25,13 @@ const FolderPlus = props => {
 };
 
 FolderPlus.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 FolderPlus.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/folder.js
+++ b/src/icons/folder.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Folder = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const Folder = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
     </svg>
   );
 };
 
 Folder.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Folder.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/git-branch.js
+++ b/src/icons/git-branch.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const GitBranch = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const GitBranch = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <line x1="6" y1="3" x2="6" y2="15" />
       <circle cx="18" cy="6" r="3" />
       <circle cx="6" cy="18" r="3" />
@@ -25,11 +26,13 @@ const GitBranch = props => {
 };
 
 GitBranch.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 GitBranch.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/git-commit.js
+++ b/src/icons/git-commit.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const GitCommit = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const GitCommit = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <circle cx="12" cy="12" r="4" />
       <line x1="1.05" y1="12" x2="7" y2="12" />
       <line x1="17.01" y1="12" x2="22.96" y2="12" />
@@ -24,11 +25,13 @@ const GitCommit = props => {
 };
 
 GitCommit.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 GitCommit.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/git-merge.js
+++ b/src/icons/git-merge.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const GitMerge = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const GitMerge = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <circle cx="18" cy="18" r="3" />
       <circle cx="6" cy="6" r="3" />
       <path d="M6 21V9a9 9 0 0 0 9 9" />
@@ -24,11 +25,13 @@ const GitMerge = props => {
 };
 
 GitMerge.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 GitMerge.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/git-pull-request.js
+++ b/src/icons/git-pull-request.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const GitPullRequest = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const GitPullRequest = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <circle cx="18" cy="18" r="3" />
       <circle cx="6" cy="6" r="3" />
       <path d="M13 6h3a2 2 0 0 1 2 2v7" />
@@ -25,11 +26,13 @@ const GitPullRequest = props => {
 };
 
 GitPullRequest.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 GitPullRequest.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/github.js
+++ b/src/icons/github.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Github = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const Github = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22" />
     </svg>
   );
 };
 
 Github.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Github.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/gitlab.js
+++ b/src/icons/gitlab.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Gitlab = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const Gitlab = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M22.65 14.39L12 22.13 1.35 14.39a.84.84 0 0 1-.3-.94l1.22-3.78 2.44-7.51A.42.42 0 0 1 4.82 2a.43.43 0 0 1 .58 0 .42.42 0 0 1 .11.18l2.44 7.49h8.1l2.44-7.51A.42.42 0 0 1 18.6 2a.43.43 0 0 1 .58 0 .42.42 0 0 1 .11.18l2.44 7.51L23 13.45a.84.84 0 0 1-.35.94z" />
     </svg>
   );
 };
 
 Gitlab.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Gitlab.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/globe.js
+++ b/src/icons/globe.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Globe = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Globe = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <circle cx="12" cy="12" r="10" />
       <line x1="2" y1="12" x2="22" y2="12" />
       <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
@@ -24,11 +25,13 @@ const Globe = props => {
 };
 
 Globe.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Globe.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/grid.js
+++ b/src/icons/grid.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Grid = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Grid = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <rect x="3" y="3" width="7" height="7" />
       <rect x="14" y="3" width="7" height="7" />
       <rect x="14" y="14" width="7" height="7" />
@@ -25,11 +26,13 @@ const Grid = props => {
 };
 
 Grid.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Grid.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/hard-drive.js
+++ b/src/icons/hard-drive.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const HardDrive = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const HardDrive = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <line x1="22" y1="12" x2="2" y2="12" />
       <path d="M5.45 5.11L2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z" />
       <line x1="6" y1="16" x2="6" y2="16" />
@@ -25,11 +26,13 @@ const HardDrive = props => {
 };
 
 HardDrive.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 HardDrive.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/hash.js
+++ b/src/icons/hash.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Hash = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Hash = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <line x1="4" y1="9" x2="20" y2="9" />
       <line x1="4" y1="15" x2="20" y2="15" />
       <line x1="10" y1="3" x2="8" y2="21" />
@@ -25,11 +26,13 @@ const Hash = props => {
 };
 
 Hash.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Hash.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/headphones.js
+++ b/src/icons/headphones.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Headphones = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Headphones = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M3 18v-6a9 9 0 0 1 18 0v6" />
       <path d="M21 19a2 2 0 0 1-2 2h-1a2 2 0 0 1-2-2v-3a2 2 0 0 1 2-2h3zM3 19a2 2 0 0 0 2 2h1a2 2 0 0 0 2-2v-3a2 2 0 0 0-2-2H3z" />
     </svg>
@@ -23,11 +24,13 @@ const Headphones = props => {
 };
 
 Headphones.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Headphones.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/heart.js
+++ b/src/icons/heart.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Heart = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const Heart = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
     </svg>
   );
 };
 
 Heart.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Heart.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/help-circle.js
+++ b/src/icons/help-circle.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const HelpCircle = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const HelpCircle = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
       <circle cx="12" cy="12" r="10" />
       <line x1="12" y1="17" x2="12" y2="17" />
@@ -24,11 +25,13 @@ const HelpCircle = props => {
 };
 
 HelpCircle.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 HelpCircle.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/home.js
+++ b/src/icons/home.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Home = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Home = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
       <polyline points="9 22 9 12 15 12 15 22" />
     </svg>
@@ -23,11 +24,13 @@ const Home = props => {
 };
 
 Home.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Home.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/image.js
+++ b/src/icons/image.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Image = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Image = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
       <circle cx="8.5" cy="8.5" r="1.5" />
       <polyline points="21 15 16 10 5 21" />
@@ -24,11 +25,13 @@ const Image = props => {
 };
 
 Image.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Image.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/inbox.js
+++ b/src/icons/inbox.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Inbox = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Inbox = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="22 12 16 12 14 15 10 15 8 12 2 12" />
       <path d="M5.45 5.11L2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z" />
     </svg>
@@ -23,11 +24,13 @@ const Inbox = props => {
 };
 
 Inbox.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Inbox.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/info.js
+++ b/src/icons/info.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Info = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Info = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <circle cx="12" cy="12" r="10" />
       <line x1="12" y1="16" x2="12" y2="12" />
       <line x1="12" y1="8" x2="12" y2="8" />
@@ -24,11 +25,13 @@ const Info = props => {
 };
 
 Info.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Info.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/instagram.js
+++ b/src/icons/instagram.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Instagram = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Instagram = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <rect x="2" y="2" width="20" height="20" rx="5" ry="5" />
       <path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z" />
       <line x1="17.5" y1="6.5" x2="17.5" y2="6.5" />
@@ -24,11 +25,13 @@ const Instagram = props => {
 };
 
 Instagram.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Instagram.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/italic.js
+++ b/src/icons/italic.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Italic = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Italic = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <line x1="19" y1="4" x2="10" y2="4" />
       <line x1="14" y1="20" x2="5" y2="20" />
       <line x1="15" y1="4" x2="9" y2="20" />
@@ -24,11 +25,13 @@ const Italic = props => {
 };
 
 Italic.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Italic.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/layers.js
+++ b/src/icons/layers.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Layers = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Layers = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polygon points="12 2 2 7 12 12 22 7 12 2" />
       <polyline points="2 17 12 22 22 17" />
       <polyline points="2 12 12 17 22 12" />
@@ -24,11 +25,13 @@ const Layers = props => {
 };
 
 Layers.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Layers.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/layout.js
+++ b/src/icons/layout.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Layout = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Layout = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
       <line x1="3" y1="9" x2="21" y2="9" />
       <line x1="9" y1="21" x2="9" y2="9" />
@@ -24,11 +25,13 @@ const Layout = props => {
 };
 
 Layout.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Layout.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/life-buoy.js
+++ b/src/icons/life-buoy.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const LifeBuoy = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const LifeBuoy = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <circle cx="12" cy="12" r="10" />
       <circle cx="12" cy="12" r="4" />
       <line x1="4.93" y1="4.93" x2="9.17" y2="9.17" />
@@ -28,11 +29,13 @@ const LifeBuoy = props => {
 };
 
 LifeBuoy.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 LifeBuoy.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/link-2.js
+++ b/src/icons/link-2.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Link2 = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Link2 = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M15 7h3a5 5 0 0 1 5 5 5 5 0 0 1-5 5h-3m-6 0H6a5 5 0 0 1-5-5 5 5 0 0 1 5-5h3" />
       <line x1="8" y1="12" x2="16" y2="12" />
     </svg>
@@ -23,11 +24,13 @@ const Link2 = props => {
 };
 
 Link2.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Link2.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/link.js
+++ b/src/icons/link.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Link = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Link = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
       <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
     </svg>
@@ -23,11 +24,13 @@ const Link = props => {
 };
 
 Link.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Link.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/linkedin.js
+++ b/src/icons/linkedin.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Linkedin = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Linkedin = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z" />
       <rect x="2" y="9" width="4" height="12" />
       <circle cx="4" cy="4" r="2" />
@@ -24,11 +25,13 @@ const Linkedin = props => {
 };
 
 Linkedin.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Linkedin.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/list.js
+++ b/src/icons/list.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const List = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const List = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <line x1="8" y1="6" x2="21" y2="6" />
       <line x1="8" y1="12" x2="21" y2="12" />
       <line x1="8" y1="18" x2="21" y2="18" />
@@ -27,11 +28,13 @@ const List = props => {
 };
 
 List.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 List.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/loader.js
+++ b/src/icons/loader.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Loader = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Loader = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <line x1="12" y1="2" x2="12" y2="6" />
       <line x1="12" y1="18" x2="12" y2="22" />
       <line x1="4.93" y1="4.93" x2="7.76" y2="7.76" />
@@ -29,11 +30,13 @@ const Loader = props => {
 };
 
 Loader.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Loader.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/lock.js
+++ b/src/icons/lock.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Lock = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Lock = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
       <path d="M7 11V7a5 5 0 0 1 10 0v4" />
     </svg>
@@ -23,11 +24,13 @@ const Lock = props => {
 };
 
 Lock.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Lock.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/log-in.js
+++ b/src/icons/log-in.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const LogIn = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const LogIn = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4" />
       <polyline points="10 17 15 12 10 7" />
       <line x1="15" y1="12" x2="3" y2="12" />
@@ -24,11 +25,13 @@ const LogIn = props => {
 };
 
 LogIn.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 LogIn.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/log-out.js
+++ b/src/icons/log-out.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const LogOut = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const LogOut = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
       <polyline points="16 17 21 12 16 7" />
       <line x1="21" y1="12" x2="9" y2="12" />
@@ -24,11 +25,13 @@ const LogOut = props => {
 };
 
 LogOut.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 LogOut.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/mail.js
+++ b/src/icons/mail.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Mail = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Mail = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z" />
       <polyline points="22,6 12,13 2,6" />
     </svg>
@@ -23,11 +24,13 @@ const Mail = props => {
 };
 
 Mail.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Mail.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/map-pin.js
+++ b/src/icons/map-pin.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const MapPin = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const MapPin = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z" />
       <circle cx="12" cy="10" r="3" />
     </svg>
@@ -23,11 +24,13 @@ const MapPin = props => {
 };
 
 MapPin.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 MapPin.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/map.js
+++ b/src/icons/map.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Map = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Map = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polygon points="1 6 1 22 8 18 16 22 23 18 23 2 16 6 8 2 1 6" />
       <line x1="8" y1="2" x2="8" y2="18" />
       <line x1="16" y1="6" x2="16" y2="22" />
@@ -24,11 +25,13 @@ const Map = props => {
 };
 
 Map.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Map.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/maximize-2.js
+++ b/src/icons/maximize-2.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Maximize2 = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Maximize2 = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="15 3 21 3 21 9" />
       <polyline points="9 21 3 21 3 15" />
       <line x1="21" y1="3" x2="14" y2="10" />
@@ -25,11 +26,13 @@ const Maximize2 = props => {
 };
 
 Maximize2.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Maximize2.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/maximize.js
+++ b/src/icons/maximize.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Maximize = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const Maximize = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M8 3H5a2 2 0 0 0-2 2v3m18 0V5a2 2 0 0 0-2-2h-3m0 18h3a2 2 0 0 0 2-2v-3M3 16v3a2 2 0 0 0 2 2h3" />
     </svg>
   );
 };
 
 Maximize.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Maximize.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/menu.js
+++ b/src/icons/menu.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Menu = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Menu = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <line x1="3" y1="12" x2="21" y2="12" />
       <line x1="3" y1="6" x2="21" y2="6" />
       <line x1="3" y1="18" x2="21" y2="18" />
@@ -24,11 +25,13 @@ const Menu = props => {
 };
 
 Menu.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Menu.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/message-circle.js
+++ b/src/icons/message-circle.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const MessageCircle = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const MessageCircle = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z" />
     </svg>
   );
 };
 
 MessageCircle.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 MessageCircle.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/message-square.js
+++ b/src/icons/message-square.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const MessageSquare = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const MessageSquare = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
     </svg>
   );
 };
 
 MessageSquare.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 MessageSquare.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/mic-off.js
+++ b/src/icons/mic-off.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const MicOff = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const MicOff = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <line x1="1" y1="1" x2="23" y2="23" />
       <path d="M9 9v3a3 3 0 0 0 5.12 2.12M15 9.34V4a3 3 0 0 0-5.94-.6" />
       <path d="M17 16.95A7 7 0 0 1 5 12v-2m14 0v2a7 7 0 0 1-.11 1.23" />
@@ -26,11 +27,13 @@ const MicOff = props => {
 };
 
 MicOff.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 MicOff.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/mic.js
+++ b/src/icons/mic.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Mic = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Mic = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z" />
       <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
       <line x1="12" y1="19" x2="12" y2="23" />
@@ -25,11 +26,13 @@ const Mic = props => {
 };
 
 Mic.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Mic.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/minimize-2.js
+++ b/src/icons/minimize-2.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Minimize2 = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Minimize2 = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="4 14 10 14 10 20" />
       <polyline points="20 10 14 10 14 4" />
       <line x1="14" y1="10" x2="21" y2="3" />
@@ -25,11 +26,13 @@ const Minimize2 = props => {
 };
 
 Minimize2.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Minimize2.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/minimize.js
+++ b/src/icons/minimize.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Minimize = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const Minimize = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M8 3v3a2 2 0 0 1-2 2H3m18 0h-3a2 2 0 0 1-2-2V3m0 18v-3a2 2 0 0 1 2-2h3M3 16h3a2 2 0 0 1 2 2v3" />
     </svg>
   );
 };
 
 Minimize.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Minimize.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/minus-circle.js
+++ b/src/icons/minus-circle.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const MinusCircle = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const MinusCircle = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <circle cx="12" cy="12" r="10" />
       <line x1="8" y1="12" x2="16" y2="12" />
     </svg>
@@ -23,11 +24,13 @@ const MinusCircle = props => {
 };
 
 MinusCircle.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 MinusCircle.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/minus-square.js
+++ b/src/icons/minus-square.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const MinusSquare = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const MinusSquare = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
       <line x1="8" y1="12" x2="16" y2="12" />
     </svg>
@@ -23,11 +24,13 @@ const MinusSquare = props => {
 };
 
 MinusSquare.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 MinusSquare.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/minus.js
+++ b/src/icons/minus.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Minus = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const Minus = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <line x1="5" y1="12" x2="19" y2="12" />
     </svg>
   );
 };
 
 Minus.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Minus.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/monitor.js
+++ b/src/icons/monitor.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Monitor = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Monitor = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <rect x="2" y="3" width="20" height="14" rx="2" ry="2" />
       <line x1="8" y1="21" x2="16" y2="21" />
       <line x1="12" y1="17" x2="12" y2="21" />
@@ -24,11 +25,13 @@ const Monitor = props => {
 };
 
 Monitor.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Monitor.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/moon.js
+++ b/src/icons/moon.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Moon = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const Moon = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
     </svg>
   );
 };
 
 Moon.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Moon.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/more-horizontal.js
+++ b/src/icons/more-horizontal.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const MoreHorizontal = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const MoreHorizontal = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <circle cx="12" cy="12" r="1" />
       <circle cx="19" cy="12" r="1" />
       <circle cx="5" cy="12" r="1" />
@@ -24,11 +25,13 @@ const MoreHorizontal = props => {
 };
 
 MoreHorizontal.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 MoreHorizontal.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/more-vertical.js
+++ b/src/icons/more-vertical.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const MoreVertical = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const MoreVertical = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <circle cx="12" cy="12" r="1" />
       <circle cx="12" cy="5" r="1" />
       <circle cx="12" cy="19" r="1" />
@@ -24,11 +25,13 @@ const MoreVertical = props => {
 };
 
 MoreVertical.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 MoreVertical.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/move.js
+++ b/src/icons/move.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Move = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Move = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="5 9 2 12 5 15" />
       <polyline points="9 5 12 2 15 5" />
       <polyline points="15 19 12 22 9 19" />
@@ -27,11 +28,13 @@ const Move = props => {
 };
 
 Move.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Move.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/music.js
+++ b/src/icons/music.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Music = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Music = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M9 17H5a2 2 0 0 0-2 2 2 2 0 0 0 2 2h2a2 2 0 0 0 2-2zm12-2h-4a2 2 0 0 0-2 2 2 2 0 0 0 2 2h2a2 2 0 0 0 2-2z" />
       <polyline points="9 17 9 5 21 3 21 15" />
     </svg>
@@ -23,11 +24,13 @@ const Music = props => {
 };
 
 Music.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Music.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/navigation-2.js
+++ b/src/icons/navigation-2.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Navigation2 = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const Navigation2 = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polygon points="12 2 19 21 12 17 5 21 12 2" />
     </svg>
   );
 };
 
 Navigation2.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Navigation2.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/navigation.js
+++ b/src/icons/navigation.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Navigation = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const Navigation = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polygon points="3 11 22 2 13 21 11 13 3 11" />
     </svg>
   );
 };
 
 Navigation.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Navigation.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/octagon.js
+++ b/src/icons/octagon.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Octagon = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const Octagon = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polygon points="7.86 2 16.14 2 22 7.86 22 16.14 16.14 22 7.86 22 2 16.14 2 7.86 7.86 2" />
     </svg>
   );
 };
 
 Octagon.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Octagon.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/package.js
+++ b/src/icons/package.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Package = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Package = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M12.89 1.45l8 4A2 2 0 0 1 22 7.24v9.53a2 2 0 0 1-1.11 1.79l-8 4a2 2 0 0 1-1.79 0l-8-4a2 2 0 0 1-1.1-1.8V7.24a2 2 0 0 1 1.11-1.79l8-4a2 2 0 0 1 1.78 0z" />
       <polyline points="2.32 6.16 12 11 21.68 6.16" />
       <line x1="12" y1="22.76" x2="12" y2="11" />
@@ -25,11 +26,13 @@ const Package = props => {
 };
 
 Package.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Package.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/paperclip.js
+++ b/src/icons/paperclip.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Paperclip = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const Paperclip = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48" />
     </svg>
   );
 };
 
 Paperclip.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Paperclip.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/pause-circle.js
+++ b/src/icons/pause-circle.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const PauseCircle = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const PauseCircle = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <circle cx="12" cy="12" r="10" />
       <line x1="10" y1="15" x2="10" y2="9" />
       <line x1="14" y1="15" x2="14" y2="9" />
@@ -24,11 +25,13 @@ const PauseCircle = props => {
 };
 
 PauseCircle.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 PauseCircle.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/pause.js
+++ b/src/icons/pause.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Pause = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Pause = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <rect x="6" y="4" width="4" height="16" />
       <rect x="14" y="4" width="4" height="16" />
     </svg>
@@ -23,11 +24,13 @@ const Pause = props => {
 };
 
 Pause.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Pause.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/percent.js
+++ b/src/icons/percent.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Percent = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Percent = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <line x1="19" y1="5" x2="5" y2="19" />
       <circle cx="6.5" cy="6.5" r="2.5" />
       <circle cx="17.5" cy="17.5" r="2.5" />
@@ -24,11 +25,13 @@ const Percent = props => {
 };
 
 Percent.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Percent.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/phone-call.js
+++ b/src/icons/phone-call.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const PhoneCall = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const PhoneCall = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M15.05 5A5 5 0 0 1 19 8.95M15.05 1A9 9 0 0 1 23 8.94m-1 7.98v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z" />
     </svg>
   );
 };
 
 PhoneCall.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 PhoneCall.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/phone-forwarded.js
+++ b/src/icons/phone-forwarded.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const PhoneForwarded = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const PhoneForwarded = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="19 1 23 5 19 9" />
       <line x1="15" y1="5" x2="23" y2="5" />
       <path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z" />
@@ -24,11 +25,13 @@ const PhoneForwarded = props => {
 };
 
 PhoneForwarded.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 PhoneForwarded.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/phone-incoming.js
+++ b/src/icons/phone-incoming.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const PhoneIncoming = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const PhoneIncoming = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="16 2 16 8 22 8" />
       <line x1="23" y1="1" x2="16" y2="8" />
       <path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z" />
@@ -24,11 +25,13 @@ const PhoneIncoming = props => {
 };
 
 PhoneIncoming.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 PhoneIncoming.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/phone-missed.js
+++ b/src/icons/phone-missed.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const PhoneMissed = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const PhoneMissed = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <line x1="23" y1="1" x2="17" y2="7" />
       <line x1="17" y1="1" x2="23" y2="7" />
       <path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z" />
@@ -24,11 +25,13 @@ const PhoneMissed = props => {
 };
 
 PhoneMissed.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 PhoneMissed.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/phone-off.js
+++ b/src/icons/phone-off.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const PhoneOff = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const PhoneOff = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M10.68 13.31a16 16 0 0 0 3.41 2.6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7 2 2 0 0 1 1.72 2v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.42 19.42 0 0 1-3.33-2.67m-2.67-3.34a19.79 19.79 0 0 1-3.07-8.63A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91" />
       <line x1="23" y1="1" x2="1" y2="23" />
     </svg>
@@ -23,11 +24,13 @@ const PhoneOff = props => {
 };
 
 PhoneOff.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 PhoneOff.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/phone-outgoing.js
+++ b/src/icons/phone-outgoing.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const PhoneOutgoing = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const PhoneOutgoing = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="23 7 23 1 17 1" />
       <line x1="16" y1="8" x2="23" y2="1" />
       <path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z" />
@@ -24,11 +25,13 @@ const PhoneOutgoing = props => {
 };
 
 PhoneOutgoing.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 PhoneOutgoing.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/phone.js
+++ b/src/icons/phone.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Phone = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const Phone = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z" />
     </svg>
   );
 };
 
 Phone.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Phone.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/pie-chart.js
+++ b/src/icons/pie-chart.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const PieChart = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const PieChart = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M21.21 15.89A10 10 0 1 1 8 2.83" />
       <path d="M22 12A10 10 0 0 0 12 2v10z" />
     </svg>
@@ -23,11 +24,13 @@ const PieChart = props => {
 };
 
 PieChart.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 PieChart.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/play-circle.js
+++ b/src/icons/play-circle.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const PlayCircle = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const PlayCircle = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <circle cx="12" cy="12" r="10" />
       <polygon points="10 8 16 12 10 16 10 8" />
     </svg>
@@ -23,11 +24,13 @@ const PlayCircle = props => {
 };
 
 PlayCircle.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 PlayCircle.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/play.js
+++ b/src/icons/play.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Play = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const Play = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polygon points="5 3 19 12 5 21 5 3" />
     </svg>
   );
 };
 
 Play.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Play.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/plus-circle.js
+++ b/src/icons/plus-circle.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const PlusCircle = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const PlusCircle = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <circle cx="12" cy="12" r="10" />
       <line x1="12" y1="8" x2="12" y2="16" />
       <line x1="8" y1="12" x2="16" y2="12" />
@@ -24,11 +25,13 @@ const PlusCircle = props => {
 };
 
 PlusCircle.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 PlusCircle.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/plus-square.js
+++ b/src/icons/plus-square.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const PlusSquare = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const PlusSquare = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
       <line x1="12" y1="8" x2="12" y2="16" />
       <line x1="8" y1="12" x2="16" y2="12" />
@@ -24,11 +25,13 @@ const PlusSquare = props => {
 };
 
 PlusSquare.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 PlusSquare.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/plus.js
+++ b/src/icons/plus.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Plus = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Plus = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <line x1="12" y1="5" x2="12" y2="19" />
       <line x1="5" y1="12" x2="19" y2="12" />
     </svg>
@@ -23,11 +24,13 @@ const Plus = props => {
 };
 
 Plus.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Plus.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/pocket.js
+++ b/src/icons/pocket.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Pocket = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Pocket = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M4 3h16a2 2 0 0 1 2 2v6a10 10 0 0 1-10 10A10 10 0 0 1 2 11V5a2 2 0 0 1 2-2z" />
       <polyline points="8 10 12 14 16 10" />
     </svg>
@@ -23,11 +24,13 @@ const Pocket = props => {
 };
 
 Pocket.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Pocket.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/power.js
+++ b/src/icons/power.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Power = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Power = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M18.36 6.64a9 9 0 1 1-12.73 0" />
       <line x1="12" y1="2" x2="12" y2="12" />
     </svg>
@@ -23,11 +24,13 @@ const Power = props => {
 };
 
 Power.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Power.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/printer.js
+++ b/src/icons/printer.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Printer = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Printer = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="6 9 6 2 18 2 18 9" />
       <path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2" />
       <rect x="6" y="14" width="12" height="8" />
@@ -24,11 +25,13 @@ const Printer = props => {
 };
 
 Printer.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Printer.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/radio.js
+++ b/src/icons/radio.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Radio = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Radio = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <circle cx="12" cy="12" r="2" />
       <path d="M16.24 7.76a6 6 0 0 1 0 8.49m-8.48-.01a6 6 0 0 1 0-8.49m11.31-2.82a10 10 0 0 1 0 14.14m-14.14 0a10 10 0 0 1 0-14.14" />
     </svg>
@@ -23,11 +24,13 @@ const Radio = props => {
 };
 
 Radio.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Radio.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/refresh-ccw.js
+++ b/src/icons/refresh-ccw.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const RefreshCcw = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const RefreshCcw = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="1 4 1 10 7 10" />
       <polyline points="23 20 23 14 17 14" />
       <path d="M20.49 9A9 9 0 0 0 5.64 5.64L1 10m22 4l-4.64 4.36A9 9 0 0 1 3.51 15" />
@@ -24,11 +25,13 @@ const RefreshCcw = props => {
 };
 
 RefreshCcw.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 RefreshCcw.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/refresh-cw.js
+++ b/src/icons/refresh-cw.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const RefreshCw = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const RefreshCw = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="23 4 23 10 17 10" />
       <polyline points="1 20 1 14 7 14" />
       <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15" />
@@ -24,11 +25,13 @@ const RefreshCw = props => {
 };
 
 RefreshCw.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 RefreshCw.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/repeat.js
+++ b/src/icons/repeat.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Repeat = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Repeat = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="17 1 21 5 17 9" />
       <path d="M3 11V9a4 4 0 0 1 4-4h14" />
       <polyline points="7 23 3 19 7 15" />
@@ -25,11 +26,13 @@ const Repeat = props => {
 };
 
 Repeat.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Repeat.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/rewind.js
+++ b/src/icons/rewind.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Rewind = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Rewind = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polygon points="11 19 2 12 11 5 11 19" />
       <polygon points="22 19 13 12 22 5 22 19" />
     </svg>
@@ -23,11 +24,13 @@ const Rewind = props => {
 };
 
 Rewind.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Rewind.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/rotate-ccw.js
+++ b/src/icons/rotate-ccw.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const RotateCcw = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const RotateCcw = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="1 4 1 10 7 10" />
       <path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10" />
     </svg>
@@ -23,11 +24,13 @@ const RotateCcw = props => {
 };
 
 RotateCcw.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 RotateCcw.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/rotate-cw.js
+++ b/src/icons/rotate-cw.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const RotateCw = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const RotateCw = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="23 4 23 10 17 10" />
       <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
     </svg>
@@ -23,11 +24,13 @@ const RotateCw = props => {
 };
 
 RotateCw.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 RotateCw.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/rss.js
+++ b/src/icons/rss.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Rss = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Rss = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M4 11a9 9 0 0 1 9 9" />
       <path d="M4 4a16 16 0 0 1 16 16" />
       <circle cx="5" cy="19" r="1" />
@@ -24,11 +25,13 @@ const Rss = props => {
 };
 
 Rss.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Rss.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/save.js
+++ b/src/icons/save.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Save = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Save = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z" />
       <polyline points="17 21 17 13 7 13 7 21" />
       <polyline points="7 3 7 8 15 8" />
@@ -24,11 +25,13 @@ const Save = props => {
 };
 
 Save.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Save.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/scissors.js
+++ b/src/icons/scissors.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Scissors = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Scissors = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <circle cx="6" cy="6" r="3" />
       <circle cx="6" cy="18" r="3" />
       <line x1="20" y1="4" x2="8.12" y2="15.88" />
@@ -26,11 +27,13 @@ const Scissors = props => {
 };
 
 Scissors.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Scissors.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/search.js
+++ b/src/icons/search.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Search = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Search = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <circle cx="11" cy="11" r="8" />
       <line x1="21" y1="21" x2="16.65" y2="16.65" />
     </svg>
@@ -23,11 +24,13 @@ const Search = props => {
 };
 
 Search.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Search.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/send.js
+++ b/src/icons/send.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Send = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Send = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <line x1="22" y1="2" x2="11" y2="13" />
       <polygon points="22 2 15 22 11 13 2 9 22 2" />
     </svg>
@@ -23,11 +24,13 @@ const Send = props => {
 };
 
 Send.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Send.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/server.js
+++ b/src/icons/server.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Server = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Server = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <rect x="2" y="2" width="20" height="8" rx="2" ry="2" />
       <rect x="2" y="14" width="20" height="8" rx="2" ry="2" />
       <line x1="6" y1="6" x2="6" y2="6" />
@@ -25,11 +26,13 @@ const Server = props => {
 };
 
 Server.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Server.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/settings.js
+++ b/src/icons/settings.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Settings = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Settings = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <circle cx="12" cy="12" r="3" />
       <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
     </svg>
@@ -23,11 +24,13 @@ const Settings = props => {
 };
 
 Settings.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Settings.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/share-2.js
+++ b/src/icons/share-2.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Share2 = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Share2 = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <circle cx="18" cy="5" r="3" />
       <circle cx="6" cy="12" r="3" />
       <circle cx="18" cy="19" r="3" />
@@ -26,11 +27,13 @@ const Share2 = props => {
 };
 
 Share2.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Share2.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/share.js
+++ b/src/icons/share.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Share = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Share = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8" />
       <polyline points="16 6 12 2 8 6" />
       <line x1="12" y1="2" x2="12" y2="15" />
@@ -24,11 +25,13 @@ const Share = props => {
 };
 
 Share.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Share.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/shield-off.js
+++ b/src/icons/shield-off.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const ShieldOff = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const ShieldOff = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M19.69 14a6.9 6.9 0 0 0 .31-2V5l-8-3-3.16 1.18" />
       <path d="M4.73 4.73L4 5v7c0 6 8 10 8 10a20.29 20.29 0 0 0 5.62-4.38" />
       <line x1="1" y1="1" x2="23" y2="23" />
@@ -24,11 +25,13 @@ const ShieldOff = props => {
 };
 
 ShieldOff.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 ShieldOff.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/shield.js
+++ b/src/icons/shield.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Shield = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const Shield = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
     </svg>
   );
 };
 
 Shield.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Shield.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/shopping-bag.js
+++ b/src/icons/shopping-bag.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const ShoppingBag = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const ShoppingBag = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M6 2L3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4z" />
       <line x1="3" y1="6" x2="21" y2="6" />
       <path d="M16 10a4 4 0 0 1-8 0" />
@@ -24,11 +25,13 @@ const ShoppingBag = props => {
 };
 
 ShoppingBag.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 ShoppingBag.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/shopping-cart.js
+++ b/src/icons/shopping-cart.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const ShoppingCart = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const ShoppingCart = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <circle cx="9" cy="21" r="1" />
       <circle cx="20" cy="21" r="1" />
       <path d="M1 1h4l2.68 13.39a2 2 0 0 0 2 1.61h9.72a2 2 0 0 0 2-1.61L23 6H6" />
@@ -24,11 +25,13 @@ const ShoppingCart = props => {
 };
 
 ShoppingCart.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 ShoppingCart.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/shuffle.js
+++ b/src/icons/shuffle.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Shuffle = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Shuffle = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="16 3 21 3 21 8" />
       <line x1="4" y1="20" x2="21" y2="3" />
       <polyline points="21 16 21 21 16 21" />
@@ -26,11 +27,13 @@ const Shuffle = props => {
 };
 
 Shuffle.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Shuffle.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/sidebar.js
+++ b/src/icons/sidebar.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Sidebar = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Sidebar = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
       <line x1="9" y1="3" x2="9" y2="21" />
     </svg>
@@ -23,11 +24,13 @@ const Sidebar = props => {
 };
 
 Sidebar.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Sidebar.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/skip-back.js
+++ b/src/icons/skip-back.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const SkipBack = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const SkipBack = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polygon points="19 20 9 12 19 4 19 20" />
       <line x1="5" y1="19" x2="5" y2="5" />
     </svg>
@@ -23,11 +24,13 @@ const SkipBack = props => {
 };
 
 SkipBack.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 SkipBack.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/skip-forward.js
+++ b/src/icons/skip-forward.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const SkipForward = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const SkipForward = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polygon points="5 4 15 12 5 20 5 4" />
       <line x1="19" y1="5" x2="19" y2="19" />
     </svg>
@@ -23,11 +24,13 @@ const SkipForward = props => {
 };
 
 SkipForward.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 SkipForward.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/slack.js
+++ b/src/icons/slack.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Slack = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Slack = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M22.08 9C19.81 1.41 16.54-.35 9 1.92S-.35 7.46 1.92 15 7.46 24.35 15 22.08 24.35 16.54 22.08 9z" />
       <line x1="12.57" y1="5.99" x2="16.15" y2="16.39" />
       <line x1="7.85" y1="7.61" x2="11.43" y2="18.01" />
@@ -26,11 +27,13 @@ const Slack = props => {
 };
 
 Slack.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Slack.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/slash.js
+++ b/src/icons/slash.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Slash = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Slash = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <circle cx="12" cy="12" r="10" />
       <line x1="4.93" y1="4.93" x2="19.07" y2="19.07" />
     </svg>
@@ -23,11 +24,13 @@ const Slash = props => {
 };
 
 Slash.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Slash.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/sliders.js
+++ b/src/icons/sliders.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Sliders = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Sliders = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <line x1="4" y1="21" x2="4" y2="14" />
       <line x1="4" y1="10" x2="4" y2="3" />
       <line x1="12" y1="21" x2="12" y2="12" />
@@ -30,11 +31,13 @@ const Sliders = props => {
 };
 
 Sliders.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Sliders.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/smartphone.js
+++ b/src/icons/smartphone.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Smartphone = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Smartphone = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <rect x="5" y="2" width="14" height="20" rx="2" ry="2" />
       <line x1="12" y1="18" x2="12" y2="18" />
     </svg>
@@ -23,11 +24,13 @@ const Smartphone = props => {
 };
 
 Smartphone.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Smartphone.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/speaker.js
+++ b/src/icons/speaker.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Speaker = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Speaker = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <rect x="4" y="2" width="16" height="20" rx="2" ry="2" />
       <circle cx="12" cy="14" r="4" />
       <line x1="12" y1="6" x2="12" y2="6" />
@@ -24,11 +25,13 @@ const Speaker = props => {
 };
 
 Speaker.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Speaker.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/square.js
+++ b/src/icons/square.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Square = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const Square = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
     </svg>
   );
 };
 
 Square.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Square.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/star.js
+++ b/src/icons/star.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Star = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const Star = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
     </svg>
   );
 };
 
 Star.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Star.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/stop-circle.js
+++ b/src/icons/stop-circle.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const StopCircle = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const StopCircle = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <circle cx="12" cy="12" r="10" />
       <rect x="9" y="9" width="6" height="6" />
     </svg>
@@ -23,11 +24,13 @@ const StopCircle = props => {
 };
 
 StopCircle.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 StopCircle.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/sun.js
+++ b/src/icons/sun.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Sun = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Sun = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <circle cx="12" cy="12" r="5" />
       <line x1="12" y1="1" x2="12" y2="3" />
       <line x1="12" y1="21" x2="12" y2="23" />
@@ -30,11 +31,13 @@ const Sun = props => {
 };
 
 Sun.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Sun.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/sunrise.js
+++ b/src/icons/sunrise.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Sunrise = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Sunrise = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M17 18a5 5 0 0 0-10 0" />
       <line x1="12" y1="2" x2="12" y2="9" />
       <line x1="4.22" y1="10.22" x2="5.64" y2="11.64" />
@@ -29,11 +30,13 @@ const Sunrise = props => {
 };
 
 Sunrise.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Sunrise.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/sunset.js
+++ b/src/icons/sunset.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Sunset = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Sunset = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M17 18a5 5 0 0 0-10 0" />
       <line x1="12" y1="9" x2="12" y2="2" />
       <line x1="4.22" y1="10.22" x2="5.64" y2="11.64" />
@@ -29,11 +30,13 @@ const Sunset = props => {
 };
 
 Sunset.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Sunset.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/tablet.js
+++ b/src/icons/tablet.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Tablet = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Tablet = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <rect
         x="4"
         y="2"
@@ -31,11 +32,13 @@ const Tablet = props => {
 };
 
 Tablet.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Tablet.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/tag.js
+++ b/src/icons/tag.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Tag = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Tag = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z" />
       <line x1="7" y1="7" x2="7" y2="7" />
     </svg>
@@ -23,11 +24,13 @@ const Tag = props => {
 };
 
 Tag.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Tag.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/target.js
+++ b/src/icons/target.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Target = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Target = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <circle cx="12" cy="12" r="10" />
       <circle cx="12" cy="12" r="6" />
       <circle cx="12" cy="12" r="2" />
@@ -24,11 +25,13 @@ const Target = props => {
 };
 
 Target.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Target.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/terminal.js
+++ b/src/icons/terminal.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Terminal = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Terminal = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="4 17 10 11 4 5" />
       <line x1="12" y1="19" x2="20" y2="19" />
     </svg>
@@ -23,11 +24,13 @@ const Terminal = props => {
 };
 
 Terminal.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Terminal.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/thermometer.js
+++ b/src/icons/thermometer.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Thermometer = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const Thermometer = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M14 14.76V3.5a2.5 2.5 0 0 0-5 0v11.26a4.5 4.5 0 1 0 5 0z" />
     </svg>
   );
 };
 
 Thermometer.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Thermometer.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/thumbs-down.js
+++ b/src/icons/thumbs-down.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const ThumbsDown = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const ThumbsDown = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M10 15v4a3 3 0 0 0 3 3l4-9V2H5.72a2 2 0 0 0-2 1.7l-1.38 9a2 2 0 0 0 2 2.3zm7-13h2.67A2.31 2.31 0 0 1 22 4v7a2.31 2.31 0 0 1-2.33 2H17" />
     </svg>
   );
 };
 
 ThumbsDown.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 ThumbsDown.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/thumbs-up.js
+++ b/src/icons/thumbs-up.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const ThumbsUp = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const ThumbsUp = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3zM7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3" />
     </svg>
   );
 };
 
 ThumbsUp.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 ThumbsUp.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/toggle-left.js
+++ b/src/icons/toggle-left.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const ToggleLeft = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const ToggleLeft = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <rect x="1" y="5" width="22" height="14" rx="7" ry="7" />
       <circle cx="8" cy="12" r="3" />
     </svg>
@@ -23,11 +24,13 @@ const ToggleLeft = props => {
 };
 
 ToggleLeft.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 ToggleLeft.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/toggle-right.js
+++ b/src/icons/toggle-right.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const ToggleRight = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const ToggleRight = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <rect x="1" y="5" width="22" height="14" rx="7" ry="7" />
       <circle cx="16" cy="12" r="3" />
     </svg>
@@ -23,11 +24,13 @@ const ToggleRight = props => {
 };
 
 ToggleRight.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 ToggleRight.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/trash-2.js
+++ b/src/icons/trash-2.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Trash2 = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Trash2 = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="3 6 5 6 21 6" />
       <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
       <line x1="10" y1="11" x2="10" y2="17" />
@@ -25,11 +26,13 @@ const Trash2 = props => {
 };
 
 Trash2.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Trash2.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/trash.js
+++ b/src/icons/trash.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Trash = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Trash = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="3 6 5 6 21 6" />
       <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
     </svg>
@@ -23,11 +24,13 @@ const Trash = props => {
 };
 
 Trash.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Trash.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/trending-down.js
+++ b/src/icons/trending-down.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const TrendingDown = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const TrendingDown = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="23 18 13.5 8.5 8.5 13.5 1 6" />
       <polyline points="17 18 23 18 23 12" />
     </svg>
@@ -23,11 +24,13 @@ const TrendingDown = props => {
 };
 
 TrendingDown.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 TrendingDown.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/trending-up.js
+++ b/src/icons/trending-up.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const TrendingUp = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const TrendingUp = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="23 6 13.5 15.5 8.5 10.5 1 18" />
       <polyline points="17 6 23 6 23 12" />
     </svg>
@@ -23,11 +24,13 @@ const TrendingUp = props => {
 };
 
 TrendingUp.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 TrendingUp.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/triangle.js
+++ b/src/icons/triangle.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Triangle = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const Triangle = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
     </svg>
   );
 };
 
 Triangle.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Triangle.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/truck.js
+++ b/src/icons/truck.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Truck = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Truck = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <rect x="1" y="3" width="15" height="13" />
       <polygon points="16 8 20 8 23 11 23 16 16 16 16 8" />
       <circle cx="5.5" cy="18.5" r="2.5" />
@@ -25,11 +26,13 @@ const Truck = props => {
 };
 
 Truck.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Truck.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/tv.js
+++ b/src/icons/tv.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Tv = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Tv = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <rect x="2" y="7" width="20" height="15" rx="2" ry="2" />
       <polyline points="17 2 12 7 7 2" />
     </svg>
@@ -23,11 +24,13 @@ const Tv = props => {
 };
 
 Tv.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Tv.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/twitter.js
+++ b/src/icons/twitter.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Twitter = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const Twitter = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M23 3a10.9 10.9 0 0 1-3.14 1.53 4.48 4.48 0 0 0-7.86 3v1A10.66 10.66 0 0 1 3 4s-4 9 5 13a11.64 11.64 0 0 1-7 2c9 5 20 0 20-11.5a4.5 4.5 0 0 0-.08-.83A7.72 7.72 0 0 0 23 3z" />
     </svg>
   );
 };
 
 Twitter.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Twitter.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/type.js
+++ b/src/icons/type.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Type = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Type = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="4 7 4 4 20 4 20 7" />
       <line x1="9" y1="20" x2="15" y2="20" />
       <line x1="12" y1="4" x2="12" y2="20" />
@@ -24,11 +25,13 @@ const Type = props => {
 };
 
 Type.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Type.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/umbrella.js
+++ b/src/icons/umbrella.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Umbrella = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const Umbrella = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M23 12a11.05 11.05 0 0 0-22 0zm-5 7a3 3 0 0 1-6 0v-7" />
     </svg>
   );
 };
 
 Umbrella.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Umbrella.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/underline.js
+++ b/src/icons/underline.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Underline = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Underline = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M6 3v7a6 6 0 0 0 6 6 6 6 0 0 0 6-6V3" />
       <line x1="4" y1="21" x2="20" y2="21" />
     </svg>
@@ -23,11 +24,13 @@ const Underline = props => {
 };
 
 Underline.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Underline.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/unlock.js
+++ b/src/icons/unlock.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Unlock = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Unlock = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
       <path d="M7 11V7a5 5 0 0 1 9.9-1" />
     </svg>
@@ -23,11 +24,13 @@ const Unlock = props => {
 };
 
 Unlock.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Unlock.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/upload-cloud.js
+++ b/src/icons/upload-cloud.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const UploadCloud = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const UploadCloud = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="16 16 12 12 8 16" />
       <line x1="12" y1="12" x2="12" y2="21" />
       <path d="M20.39 18.39A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.3" />
@@ -25,11 +26,13 @@ const UploadCloud = props => {
 };
 
 UploadCloud.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 UploadCloud.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/upload.js
+++ b/src/icons/upload.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Upload = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Upload = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
       <polyline points="17 8 12 3 7 8" />
       <line x1="12" y1="3" x2="12" y2="15" />
@@ -24,11 +25,13 @@ const Upload = props => {
 };
 
 Upload.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Upload.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/user-check.js
+++ b/src/icons/user-check.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const UserCheck = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const UserCheck = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
       <circle cx="8.5" cy="7" r="4" />
       <polyline points="17 11 19 13 23 9" />
@@ -24,11 +25,13 @@ const UserCheck = props => {
 };
 
 UserCheck.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 UserCheck.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/user-minus.js
+++ b/src/icons/user-minus.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const UserMinus = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const UserMinus = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
       <circle cx="8.5" cy="7" r="4" />
       <line x1="23" y1="11" x2="17" y2="11" />
@@ -24,11 +25,13 @@ const UserMinus = props => {
 };
 
 UserMinus.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 UserMinus.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/user-plus.js
+++ b/src/icons/user-plus.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const UserPlus = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const UserPlus = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
       <circle cx="8.5" cy="7" r="4" />
       <line x1="20" y1="8" x2="20" y2="14" />
@@ -25,11 +26,13 @@ const UserPlus = props => {
 };
 
 UserPlus.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 UserPlus.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/user-x.js
+++ b/src/icons/user-x.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const UserX = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const UserX = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
       <circle cx="8.5" cy="7" r="4" />
       <line x1="18" y1="8" x2="23" y2="13" />
@@ -25,11 +26,13 @@ const UserX = props => {
 };
 
 UserX.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 UserX.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/user.js
+++ b/src/icons/user.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const User = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const User = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
       <circle cx="12" cy="7" r="4" />
     </svg>
@@ -23,11 +24,13 @@ const User = props => {
 };
 
 User.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 User.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/users.js
+++ b/src/icons/users.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Users = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Users = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
       <circle cx="9" cy="7" r="4" />
       <path d="M23 21v-2a4 4 0 0 0-3-3.87" />
@@ -25,11 +26,13 @@ const Users = props => {
 };
 
 Users.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Users.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/video-off.js
+++ b/src/icons/video-off.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const VideoOff = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const VideoOff = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M16 16v1a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2h2m5.66 0H14a2 2 0 0 1 2 2v3.34l1 1L23 7v10" />
       <line x1="1" y1="1" x2="23" y2="23" />
     </svg>
@@ -23,11 +24,13 @@ const VideoOff = props => {
 };
 
 VideoOff.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 VideoOff.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/video.js
+++ b/src/icons/video.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Video = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Video = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polygon points="23 7 16 12 23 17 23 7" />
       <rect x="1" y="5" width="15" height="14" rx="2" ry="2" />
     </svg>
@@ -23,11 +24,13 @@ const Video = props => {
 };
 
 Video.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Video.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/voicemail.js
+++ b/src/icons/voicemail.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Voicemail = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Voicemail = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <circle cx="5.5" cy="11.5" r="4.5" />
       <circle cx="18.5" cy="11.5" r="4.5" />
       <line x1="5.5" y1="16" x2="18.5" y2="16" />
@@ -24,11 +25,13 @@ const Voicemail = props => {
 };
 
 Voicemail.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Voicemail.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/volume-1.js
+++ b/src/icons/volume-1.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Volume1 = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Volume1 = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
       <path d="M15.54 8.46a5 5 0 0 1 0 7.07" />
     </svg>
@@ -23,11 +24,13 @@ const Volume1 = props => {
 };
 
 Volume1.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Volume1.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/volume-2.js
+++ b/src/icons/volume-2.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Volume2 = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Volume2 = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
       <path d="M19.07 4.93a10 10 0 0 1 0 14.14M15.54 8.46a5 5 0 0 1 0 7.07" />
     </svg>
@@ -23,11 +24,13 @@ const Volume2 = props => {
 };
 
 Volume2.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Volume2.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/volume-x.js
+++ b/src/icons/volume-x.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const VolumeX = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const VolumeX = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
       <line x1="23" y1="9" x2="17" y2="15" />
       <line x1="17" y1="9" x2="23" y2="15" />
@@ -24,11 +25,13 @@ const VolumeX = props => {
 };
 
 VolumeX.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 VolumeX.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/volume.js
+++ b/src/icons/volume.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Volume = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const Volume = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
     </svg>
   );
 };
 
 Volume.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Volume.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/watch.js
+++ b/src/icons/watch.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Watch = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Watch = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <circle cx="12" cy="12" r="7" />
       <polyline points="12 9 12 12 13.5 13.5" />
       <path d="M16.51 17.35l-.35 3.83a2 2 0 0 1-2 1.82H9.83a2 2 0 0 1-2-1.82l-.35-3.83m.01-10.7l.35-3.83A2 2 0 0 1 9.83 1h4.35a2 2 0 0 1 2 1.82l.35 3.83" />
@@ -24,11 +25,13 @@ const Watch = props => {
 };
 
 Watch.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Watch.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/wifi-off.js
+++ b/src/icons/wifi-off.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const WifiOff = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const WifiOff = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <line x1="1" y1="1" x2="23" y2="23" />
       <path d="M16.72 11.06A10.94 10.94 0 0 1 19 12.55" />
       <path d="M5 12.55a10.94 10.94 0 0 1 5.17-2.39" />
@@ -28,11 +29,13 @@ const WifiOff = props => {
 };
 
 WifiOff.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 WifiOff.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/wifi.js
+++ b/src/icons/wifi.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Wifi = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const Wifi = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M5 12.55a11 11 0 0 1 14.08 0" />
       <path d="M1.42 9a16 16 0 0 1 21.16 0" />
       <path d="M8.53 16.11a6 6 0 0 1 6.95 0" />
@@ -25,11 +26,13 @@ const Wifi = props => {
 };
 
 Wifi.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Wifi.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/wind.js
+++ b/src/icons/wind.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Wind = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const Wind = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <path d="M9.59 4.59A2 2 0 1 1 11 8H2m10.59 11.41A2 2 0 1 0 14 16H2m15.73-8.27A2.5 2.5 0 1 1 19.5 12H2" />
     </svg>
   );
 };
 
 Wind.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Wind.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/x-circle.js
+++ b/src/icons/x-circle.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const XCircle = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const XCircle = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <circle cx="12" cy="12" r="10" />
       <line x1="15" y1="9" x2="9" y2="15" />
       <line x1="9" y1="9" x2="15" y2="15" />
@@ -24,11 +25,13 @@ const XCircle = props => {
 };
 
 XCircle.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 XCircle.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/x-square.js
+++ b/src/icons/x-square.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const XSquare = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const XSquare = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
       <line x1="9" y1="9" x2="15" y2="15" />
       <line x1="15" y1="9" x2="9" y2="15" />
@@ -24,11 +25,13 @@ const XSquare = props => {
 };
 
 XSquare.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 XSquare.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/x.js
+++ b/src/icons/x.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const X = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const X = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <line x1="18" y1="6" x2="6" y2="18" />
       <line x1="6" y1="6" x2="18" y2="18" />
     </svg>
@@ -23,11 +24,13 @@ const X = props => {
 };
 
 X.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 X.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/zap-off.js
+++ b/src/icons/zap-off.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const ZapOff = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const ZapOff = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polyline points="12.41 6.75 13 2 10.57 4.92" />
       <polyline points="18.57 12.91 21 10 15.66 10" />
       <polyline points="8 8 3 14 12 14 11 22 16 16" />
@@ -25,11 +26,13 @@ const ZapOff = props => {
 };
 
 ZapOff.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 ZapOff.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/zap.js
+++ b/src/icons/zap.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Zap = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,17 +16,20 @@ const Zap = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" />
     </svg>
   );
 };
 
 Zap.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Zap.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/zoom-in.js
+++ b/src/icons/zoom-in.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const ZoomIn = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const ZoomIn = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <circle cx="11" cy="11" r="8" />
       <line x1="21" y1="21" x2="16.65" y2="16.65" />
       <line x1="11" y1="8" x2="11" y2="14" />
@@ -25,11 +26,13 @@ const ZoomIn = props => {
 };
 
 ZoomIn.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 ZoomIn.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };

--- a/src/icons/zoom-out.js
+++ b/src/icons/zoom-out.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const ZoomOut = props => {
-  const { color, size, ...otherProps } = props;
+  const { children, color, size, ...otherProps } = props;
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -16,6 +16,7 @@ const ZoomOut = props => {
       strokeLinejoin="round"
       {...otherProps}
     >
+      {children}
       <circle cx="11" cy="11" r="8" />
       <line x1="21" y1="21" x2="16.65" y2="16.65" />
       <line x1="8" y1="11" x2="14" y2="11" />
@@ -24,11 +25,13 @@ const ZoomOut = props => {
 };
 
 ZoomOut.propTypes = {
+  children: PropTypes.object,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 ZoomOut.defaultProps = {
+  children: null,
   color: 'currentColor',
   size: '24',
 };


### PR DESCRIPTION
## Description

Adds children prop to all icons. Useful for adding `<animate>`, `<animateTransform>`, etc elements to icons. 

[mdn: `<animate>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/animate)
[mdn: `<animateTransform>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/animateTransform)