### PR TITLE
Add peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,5 +43,9 @@
     "glob": "^7.1.2",
     "prettier": "^1.13.7",
     "uppercamelcase": "^3.0.0"
+  },
+  "peerDependencies": {
+    "react": ">= 15",
+    "prop-types": ">= 15"
   }
 }


### PR DESCRIPTION
I've added `react` and `prop-types` as a peer dependencies cause it sounds like a correct way and absence of it prevents tools like https://bundlephobia.com/result?p=react-feather calculate package size