### PR TITLE
Fix GitHub spelling

### DIFF
--- a/src/icons/github.js
+++ b/src/icons/github.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const Github = props => {
+const GitHub = props => {
   const { color, size, ...otherProps } = props;
   return (
     <svg
@@ -21,14 +21,14 @@ const Github = props => {
   );
 };
 
-Github.propTypes = {
+GitHub.propTypes = {
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
-Github.defaultProps = {
+GitHub.defaultProps = {
   color: 'currentColor',
   size: '24',
 };
 
-export default Github;
+export default GitHub;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -119,7 +119,7 @@ export const GitBranch: Icon;
 export const GitCommit: Icon;
 export const GitMerge: Icon;
 export const GitPullRequest: Icon;
-export const Github: Icon;
+export const GitHub: Icon;
 export const Gitlab: Icon;
 export const Globe: Icon;
 export const Grid: Icon;

--- a/src/index.js
+++ b/src/index.js
@@ -110,7 +110,7 @@ export GitBranch from './icons/git-branch';
 export GitCommit from './icons/git-commit';
 export GitMerge from './icons/git-merge';
 export GitPullRequest from './icons/git-pull-request';
-export Github from './icons/github';
+export GitHub from './icons/github';
 export Gitlab from './icons/gitlab';
 export Globe from './icons/globe';
 export Grid from './icons/grid';


### PR DESCRIPTION
It's "GitHub" not "Github", almost thought the icon didn't exist in this react version of Feather! 😅 