### PR TITLE
Add Table icon (from Feather v4.29.0)

### DIFF
--- a/src/icons/table.js
+++ b/src/icons/table.js
@@ -1,0 +1,31 @@
+import React, { forwardRef } from 'react';
+import PropTypes from 'prop-types';
+
+const Table = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+  return (
+    <svg
+      ref={ref}
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke={color}
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...rest}
+    >
+      <path d="M9 3H5a2 2 0 0 0-2 2v4m6-6h10a2 2 0 0 1 2 2v4M9 3v18m0 0h10a2 2 0 0 0 2-2V9M9 21H5a2 2 0 0 1-2-2V9m0 0h18" />
+    </svg>
+  );
+});
+
+Table.propTypes = {
+  color: PropTypes.string,
+  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+};
+
+Table.displayName = 'Table';
+
+export default Table;

--- a/src/index.js
+++ b/src/index.js
@@ -232,6 +232,7 @@ export { default as StopCircle } from './icons/stop-circle';
 export { default as Sun } from './icons/sun';
 export { default as Sunrise } from './icons/sunrise';
 export { default as Sunset } from './icons/sunset';
+export { default as Table } from './icons/table';
 export { default as Tablet } from './icons/tablet';
 export { default as Tag } from './icons/tag';
 export { default as Target } from './icons/target';


### PR DESCRIPTION
This Pull Requests adds the Table icon from [Feather v4.29.0](https://github.com/feathericons/feather/releases/tag/v4.29.0).